### PR TITLE
feat: Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -3,31 +3,23 @@ description: Report bugs
 labels: ['bug']
 body:
   - type: textarea
-    id: description
-    attributes:
-      label: Bug description
-      description: A clear and concise description of what the bug is.
-      placeholder: I observed the following...
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: What is the expected behavior?
-      description: A clear and concise description of the expected behavior.
-      placeholder: I expected it to...
-    validations:
-      required: true
-  - type: textarea
     id: steps
     attributes:
-      label: 'Steps to reproduce:'
-      description: Exact steps to reproduce the behaviour, if applicable include screenshots to help explain the issue.
+      label: Observed behavior
+      description: A clear description of the expected behavior. Steps to reproducde, logs, etc.
       value: |
         1. Step
         2. Step
         3. Step
         ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear description of the expected behavior.
+      placeholder: I expected it to...
     validations:
       required: true
   - type: input
@@ -44,15 +36,6 @@ body:
       label: 'Platform:'
       description: Platform on which this behaviour was observed.
       placeholder: Windows XP
-    validations:
-      required: false
-  - type: textarea
-    id: debug_logs
-    attributes:
-      label: Build or installation Logs.
-      description: Build or installation log goes here, should contain the backtrace, as well as the reset source if it is a crash.
-      placeholder: Your log goes here.
-      render: plain
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -3,10 +3,10 @@ description: Suggest an idea for this project.
 labels: ['enhancement']
 body:
   - type: textarea
-    id: problem-related
+    id: motivation
     attributes:
-      label: Problem statement
-      description: What problem does this feature solve? A clear and concise description of what the problem is.
+      label: Motvation statement
+      description: What problem does this feature solve? A clear and concise description of what the problem is or the motivation behind the change.
       placeholder: I'm always frustrated when ...
     validations:
       required: true
@@ -20,11 +20,11 @@ body:
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives
+      label: Alternative solution
       description: What are the alternative solutions? A clear and concise description of any alternative solutions or features you've considered.
       placeholder: Choosing other approach wouldn't work, because ...
     validations:
-      required: true
+      required: false
   - type: textarea
     id: context
     attributes:
@@ -40,7 +40,7 @@ body:
       description: Are there any risks asociated with this feature? A clear and concise description of any risks associated with this feature.
       placeholder: Data integrity is a risk, because ...
     validations:
-      required: true
+      required: false
   - type: textarea
     id: subtasks
     attributes:

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -1,0 +1,18 @@
+name: Other
+description: Changes that are not necessarily a feature or a bugfix
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motvation statement
+      description: Why does this change need to happen?
+      placeholder: I'm always frustrated when ...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution/Implementation
+      description: Your plan for the change
+    validations:
+      required: true


### PR DESCRIPTION
After discussing with @SquaredPotato and after writing the Way of working github wiki doc, the issue templates needed updates.

This rewords the existing templates, makes some stuff not required anymore, and adds a new template: other. This is meant for changes that are not necessarily a feature or a bugfix.
For example: Ci related changes, dependency updates, etc.

This also disables the use of empty issues, which is now possible by the aforementioned 'other' template.